### PR TITLE
WIP: Make the implementation more class oriented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+Tests/Outputs

--- a/abstract_model.py
+++ b/abstract_model.py
@@ -11,6 +11,7 @@ class BlockTypes(object):
     CommentType = 5
     ConditionType = 6
     ChangelogTagType = 7
+    PackageTagType = 8
 
 class BlockTypeMismatchException(Exception):
     pass
@@ -26,7 +27,8 @@ keys_list = [
     ['keyword', 'name'],
     ['content'],
     ['keyword', 'expression', 'content', 'else_keyword', 'else_body', 'end_keyword'],
-    ['author', 'date', 'mark', 'comment']
+    ['author', 'date', 'mark', 'comment'],
+    ['keyword', 'name', 'parameters', 'subname', 'content'],
 ]
 
 class RawSpecFile(object):

--- a/abstract_model.py
+++ b/abstract_model.py
@@ -12,7 +12,11 @@ class BlockTypes(object):
     ConditionType = 6
     ChangelogTagType = 7
 
+class BlockTypeMismatchException(Exception):
+    pass
 
+class BlockTypeUnknown(Exception):
+    pass
 
 keys_list = [
     ['key', 'option', 'content'],

--- a/metastring.py
+++ b/metastring.py
@@ -1,7 +1,293 @@
 import re
 
-from abstract_model import keys_list
+from abstract_model import keys_list, BlockTypes, BlockTypeMismatchException
+from specparser import HeaderTagBlock, ChangelogBlock, SectionBlock, ConditionBlock, MacroConditionBlock, MacroDefinitionBlock, CommentBlock
 
+class KeyMetastring(object):
+    def __init__(self):
+        self._left_ws = ""
+        self._right_ws = ""
+        self._idx = -1
+
+    def fromBlock(self, string, idx):
+        if not isinstance(string, basestring):
+            return self
+
+        self._idx = idx
+        if string == None:
+            return self
+
+        if string.isspace():
+            self._right_ws = string
+            return self
+
+        self._left_ws = string[:len(string) - len(string.lstrip())]
+        self._right_ws = string[len(string.rstrip()):]
+
+        return self
+
+    @staticmethod
+    def cleanBlock(string):
+        if string == None:
+            return None
+
+        if isinstance(string, basestring):
+            return string.strip()
+
+        return string
+
+    def to_str(self):
+        if self._idx == -1:
+            return ""
+
+        return "{}%{}{}".format(self._left_ws, self._idx, self._right_ws)
+
+class HeaderTagMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.HeaderTagType
+        self._key = None
+        self._option = None
+        self._content = None
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.HeaderTagType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected HeaderTagType, got {} instead".format(block.block_type))
+
+        self._key = KeyMetastring().fromBlock(block.key, 0)
+        self._option = KeyMetastring().fromBlock(block.option, 1)
+        self._content = KeyMetastring().fromBlock(block.content, 2)
+
+        return self
+
+    def cleanBlockType(self, block):
+        return HeaderTagBlock(
+            KeyMetastring.cleanBlock(block.key),
+            KeyMetastring.cleanBlock(block.content),
+            KeyMetastring.cleanBlock(block.option)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._key, self._option, self._content]:
+            metastring += ms.to_str()
+        return metastring
+
+class SectionMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.SectionTagType
+        self._keyword = None
+        self._content = None
+        self._parameters = None
+        self._subname = None
+        self._name = None
+        self._section_type = ""
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.SectionTagType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected SectionTagType, got {} instead".format(block.block_type))
+
+        self._keyword = KeyMetastring().fromBlock(block.keyword, 0)
+        # Given the section keyword is not checked, its content can be basically anything.
+        # Either string, array, dictionary. However, only the string content
+        # can be metastringed and the current implemention of the metastring extraction
+        # skips all non-string contents. So the section metastring gets extracted
+        # before its non-string content is processed.
+        self._name = KeyMetastring().fromBlock(block.name, 1)
+        self._parameters = KeyMetastring().fromBlock(block.parameters, 2)
+        self._subname = KeyMetastring().fromBlock(block.subname, 3)
+        self._content = KeyMetastring().fromBlock(block.content, 4)
+        self._section_type = block.keyword.strip()
+
+        return self
+
+    def cleanBlockType(self, block):
+        return SectionBlock(
+            KeyMetastring.cleanBlock(block.keyword),
+            KeyMetastring.cleanBlock(block.parameters),
+            KeyMetastring.cleanBlock(block.name),
+            KeyMetastring.cleanBlock(block.subname),
+            KeyMetastring.cleanBlock(block.content)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._keyword, self._name, self._parameters, self._subname, self._content]:
+            metastring += ms.to_str()
+        # TODO(jchaloup): why do we need this?
+        if self._section_type == "package":
+            metastring += "%4"
+        return metastring
+
+class ConditionMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.ConditionType
+        self._keyword = None
+        self._expression = None
+        self._content = None
+        self._else_body = None
+        self._end_keyword = None
+        self._else_keyword = None
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.ConditionType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected ConditionType, got {} instead".format(block.block_type))
+
+        self._keyword = KeyMetastring().fromBlock(block.keyword, 0)
+        self._expression = KeyMetastring().fromBlock(block.expression, 1)
+        self._content = KeyMetastring().fromBlock(block.content, 2)
+        self._else_keyword = KeyMetastring().fromBlock(block.else_keyword, 3)
+        self._else_body = KeyMetastring().fromBlock(block.else_body, 4)
+        self._end_keyword = KeyMetastring().fromBlock(block.end_keyword, 5)
+
+        return self
+
+    def cleanBlockType(self, block):
+        return ConditionBlock(
+            KeyMetastring.cleanBlock(block.keyword),
+            KeyMetastring.cleanBlock(block.expression),
+            KeyMetastring.cleanBlock(block.content),
+            KeyMetastring.cleanBlock(block.else_body),
+            KeyMetastring.cleanBlock(block.end_keyword),
+            KeyMetastring.cleanBlock(block.else_keyword)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._keyword, self._expression, self._content, self._else_keyword, self._else_body, self._end_keyword]:
+            metastring += ms.to_str()
+        return metastring
+
+class MacroConditionMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.MacroConditionType
+        self._condition = None
+        self._name = None
+        self._content = None
+        self._ending = None
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.MacroConditionType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected MacroConditionType, got {} instead".format(block.block_type))
+
+        self._condition = KeyMetastring().fromBlock(block.condition, 0)
+        self._name = KeyMetastring().fromBlock(block.name, 1)
+        self._content = KeyMetastring().fromBlock(block.content, 2)
+        self._ending = KeyMetastring().fromBlock(block.ending, 3)
+
+        return self
+
+    def cleanBlockType(self, block):
+        return MacroConditionBlock(
+            KeyMetastring.cleanBlock(block.name),
+            KeyMetastring.cleanBlock(block.condition),
+            KeyMetastring.cleanBlock(block.content),
+            KeyMetastring.cleanBlock(block.ending)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._condition, self._name, self._content, self._ending]:
+            metastring += ms.to_str()
+        return metastring
+
+class MacroDefinitionMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.MacroDefinitionType
+        self._keyword = None
+        self._name = None
+        self._options = None
+        self._body = None
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.MacroDefinitionType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected MacroDefinitionType, got {} instead".format(block.block_type))
+
+        self._keyword = KeyMetastring().fromBlock(block.keyword, 0)
+        self._name = KeyMetastring().fromBlock(block.name, 1)
+        self._options = KeyMetastring().fromBlock(block.options, 2)
+        self._body = KeyMetastring().fromBlock(block.body, 3)
+
+        return self
+
+    def cleanBlockType(self, block):
+        return MacroDefinitionBlock(
+            KeyMetastring.cleanBlock(block.name),
+            KeyMetastring.cleanBlock(block.keyword),
+            KeyMetastring.cleanBlock(block.options),
+            KeyMetastring.cleanBlock(block.body)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._keyword, self._name, self._options, self._body]:
+            metastring += ms.to_str()
+        return metastring
+
+class CommentMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.CommentType
+        self._content = None
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.CommentType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected CommentType, got {} instead".format(block.block_type))
+
+        self._content = KeyMetastring().fromBlock(block.content, 0)
+
+        return self
+
+    def cleanBlockType(self, block):
+        return CommentBlock(
+            KeyMetastring.cleanBlock(block.content),
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._content]:
+            metastring += ms.to_str()
+        return metastring
+
+class ChangelogMetastring(object):
+    def __init__(self):
+        self._type = BlockTypes.ChangelogTagType
+        self._keyword = None
+        self._content = []
+
+    def fromBlockType(self, block):
+        if block.block_type != BlockTypes.SectionTagType:
+            # TODO(jchaloup): replace the block type number with a string name
+            raise BlockTypeMismatchException("Expected ChangelogTagType, got {} instead".format(block.block_type))
+
+        if not isinstance(block.content, list):
+            raise TypeError("Expected Changelog content to be a list, got {} instead".format(type(block.content)))
+
+        self._keyword = KeyMetastring().fromBlock(block.keyword, 0)
+        for item in block.content:
+            self._content.append( KeyMetastring().fromBlock(item, 4) )
+
+        return self
+
+    def cleanBlockType(self, block):
+        content = []
+        for item in block.content:
+            content.append(KeyMetastring.cleanBlock(item))
+
+        return ChangelogBlock(
+            KeyMetastring.cleanBlock(block.keyword),
+            KeyMetastring.cleanBlock(content)
+        )
+
+    def to_str(self):
+        metastring = ""
+        for ms in [self._keyword] + self._content:
+            metastring += ms.to_str()
+        return metastring
 
 
 class Metastring(object):
@@ -37,7 +323,7 @@ class Metastring(object):
     @staticmethod
     def create_metastring(single_block, block_type):
         """Create metastring for the given block single_block of type block_type.
-        
+
         Example:
             single_block = {u'content': u'\t3.1.6\n', u'block_type': 0, u'option': None, u'key': u'Version'}
             block_type = 0
@@ -73,7 +359,7 @@ class Metastring(object):
     @staticmethod
     def remove_block_ids(metastring):
         """Remove block type ids and sequence numbers from metastring.
-        
+
         Example:
             metastring = '#00%0 %2\n#01%0 %2\n'
             return: '#%0 %2\n#%0 %2\n'"""
@@ -84,7 +370,7 @@ class Metastring(object):
     @staticmethod
     def replace_field_number(metastring, prev_section_count, replacing):
         """In metastring, replace replacing[0] with '!' + replacing[1] + prev_section_count.
-        
+
         Example:
             metastring = '#50%0\n \n#20%0 %1   %3\n#21%0 %1      %3 \n'
             prev_section_count = 8
@@ -100,7 +386,7 @@ class Metastring(object):
     @staticmethod
     def change_metastring(metastring, index_old, index_new, unit_index):
         """In metastring, replace '!2' + index_old with '2<' + unit_index + '>' + index_new.
-        
+
         Example:
             metastring = '#!20[55]%0        %2\n'
             index_old = 0

--- a/model_methods.py
+++ b/model_methods.py
@@ -6,7 +6,7 @@ from abstract_model import SpecfileClass, BlockTypes, keys_list
 from abstract_model import prettyprint_headervalue_position, prettyprint_macroname_position, BlockTypeUnknown
 from specparser import RawSpecFileParser
 from metastring import Metastring
-from specmodel import SpecModel
+from specmodel import SpecModelGenerator
 
 Specfile = SpecfileClass('Specfile 1.0')
 metastring_list = []
@@ -39,7 +39,7 @@ def create_abstract_model(input_filepath):
         Specfile.block_list = json_containing_parsed_spec['block_list']
         Specfile.metastring = json_containing_parsed_spec['metastring']
     else:
-        spec_model = SpecModel().fromRawSpecfile(raw)
+        spec_model = SpecModelGenerator().fromRawSpecfile(raw)
         data = spec_model.model_to_json()
         Specfile.metastring = data["metastring"]
         Specfile.block_list = json.loads(json.dumps(data["block_list"], sort_keys=True))

--- a/specmodel.py
+++ b/specmodel.py
@@ -1,0 +1,140 @@
+from abstract_model import BlockTypes
+from metastring import HeaderTagMetastring, SectionMetastring, ConditionMetastring, MacroConditionMetastring, MacroDefinitionMetastring, CommentMetastring, ChangelogMetastring
+
+class SpecModel(object):
+    def __init__(self):
+        self._block_list = []
+
+        self._beginning = ""
+        self._metastrings = []
+        self._end = ""
+
+    def fromRawSpecfile(self, raw):
+        self._beginning = raw.beginning
+        self._end = raw.end
+        self._block_list, self._metastrings = self._processBlockList(raw.block_list)
+
+        return self
+
+    def _processBlockList(self, block_list, predicate_list = []):
+        processed_blocks = []
+        generated_metastrings = []
+
+        for single_block in block_list:
+
+            if single_block.block_type == BlockTypes.HeaderTagType:
+                generated_metastrings.append( HeaderTagMetastring().fromBlockType(single_block).to_str() )
+                clean_block = HeaderTagMetastring().cleanBlockType(single_block)
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            if single_block.block_type == BlockTypes.CommentType:
+                generated_metastrings.append( CommentMetastring().fromBlockType(single_block).to_str() )
+                clean_block = CommentMetastring().cleanBlockType(single_block)
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            if single_block.block_type == BlockTypes.MacroDefinitionType:
+                generated_metastrings.append( MacroDefinitionMetastring().fromBlockType(single_block).to_str() )
+                clean_block = MacroDefinitionMetastring().cleanBlockType(single_block)
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            if single_block.block_type == BlockTypes.SectionTagType:
+                if single_block.keyword.strip() == "changelog":
+                    generated_metastrings.append( ChangelogMetastring().fromBlockType(single_block).to_str() )
+                    clean_block = ChangelogMetastring().cleanBlockType(single_block)
+                    if predicate_list != []:
+                        # TODO(jchaloup): register the AP in the conditioner table as well
+                        clean_block.AP = predicate_list
+                    processed_blocks.append(clean_block)
+                    continue
+
+                if single_block.keyword.strip() == "package":
+                    clean_block = SectionMetastring().cleanBlockType(single_block)
+                    generated_metastrings.append( SectionMetastring().fromBlockType(single_block).to_str() )
+
+                    if single_block.content != []:
+                        clean_block.content, metastring_children = self._processBlockList(single_block.content, predicate_list)
+                        generated_metastrings.append(metastring_children)
+
+                    if predicate_list != []:
+                        # TODO(jchaloup): register the AP in the conditioner table as well
+                        clean_block.AP = predicate_list
+                    processed_blocks.append(clean_block)
+                    continue
+
+                generated_metastrings.append( SectionMetastring().fromBlockType(single_block).to_str() )
+                clean_block = SectionMetastring().cleanBlockType(single_block)
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            if single_block.block_type == BlockTypes.ConditionType:
+                generated_metastrings.append( ConditionMetastring().fromBlockType(single_block).to_str() )
+                clean_block = ConditionMetastring().cleanBlockType(single_block)
+
+                if single_block.content != []:
+                    clean_block.content, content_metastring_children = self._processBlockList(single_block.content, predicate_list + [[clean_block.expression, 1, clean_block.keyword]])
+                    generated_metastrings.append(content_metastring_children)
+                if single_block.else_body != []:
+                    clean_block.else_body, else_body_metastring_children = self._processBlockList(single_block.else_body, predicate_list + [[clean_block.expression, 0, clean_block.keyword]])
+                    generated_metastrings.append(else_body_metastring_children)
+
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            if single_block.block_type == BlockTypes.MacroConditionType:
+                generated_metastrings.append( MacroConditionMetastring().fromBlockType(single_block).to_str() )
+                clean_block = MacroConditionMetastring().cleanBlockType(single_block)
+
+                if single_block.content != []:
+                    if '!' in single_block.condition:
+                        clean_block.content, metastring_children = self._processBlockList(single_block.content, predicate_list + [[clean_block.name, 0, None]])
+                    else:
+                        clean_block.content, metastring_children = self._processBlockList(single_block.content, predicate_list + [[clean_block.name, 1, None]])
+
+                    generated_metastrings.append(metastring_children)
+
+                if predicate_list != []:
+                    # TODO(jchaloup): register the AP in the conditioner table as well
+                    clean_block.AP = predicate_list
+                processed_blocks.append(clean_block)
+                continue
+
+            raise BlockTypeUnknown("Block type {} unknown".format(single_block.block_type))
+
+        return processed_blocks, generated_metastrings
+
+    def _metastring_list_to_str(self, metastring_list):
+        str = ""
+        for item in metastring_list:
+            if isinstance(item, list):
+                str += self._metastring_list_to_str(item)
+                continue
+            str += "#" + item
+
+        return str
+
+    def metastrings_to_str(self):
+        return self._beginning + self._metastring_list_to_str(self._metastrings) + self._end
+
+    def model_to_json(self):
+        return {
+            "block_list": map(lambda l: l.to_json(), self._block_list),
+            "metastring": self.metastrings_to_str(),
+        }

--- a/specmodel.py
+++ b/specmodel.py
@@ -1,18 +1,76 @@
 from abstract_model import BlockTypes
 from metastring import HeaderTagMetastring, SectionMetastring, ConditionMetastring, MacroConditionMetastring, MacroDefinitionMetastring, CommentMetastring, ChangelogMetastring
 
+# Condition-free layout of a specfile 2.0
+#
+# Metadata:
+# - Tags: []
+# - Macros: []
+# Packages: []
+# Descriptions: []
+# Files: []
+# Prep: {}
+# Install: {}
+# Changelog: {}
+# OtherSections: {}
+#
+# Integration of Conditions:
+# - register each condition expression in a conditioner table
+# - have metastrings of conditions refer to the conditioner table
+# - propagation of contidion is managed on a level of the layout (above)
+#   each block conditions refer corresponding condition expression on the conditioner table
+# - the conditioner table also counts the number of allocation of a condition (used during macro evaluations)
+#
+# Conditioner table
+# - if-condition (used to construct AP of a block)
+# - if-condition (used to construct AP of a block)
+# - !if-condition (artificial condition?)
+class ModelTypes:
+    Tag = 0
+    Macros = 1
+    Package = 2
+    Description = 3
+    Files = 4
+    OtherSection = 5
+    Comment = 6
+    Condition = 7
+    Prep = 8
+    Build = 9
+    Install = 10
+    Check = 11
+    Changelog = 12
+
 class SpecModel(object):
     def __init__(self):
+        # metastring extraction from a raw specfile
         self._block_list = []
-
         self._beginning = ""
         self._metastrings = []
         self._end = ""
+        # abstract specfile modeling
+        self._metadata_tags = []
+        self._metadata_macros = []
+        self._packages = []
+        self._descriptions = []
+        self._files = []
+        self._prep = {}
+        self._build = {}
+        self._install = {}
+        self._check = {}
+        self._changelog = {}
+        self._other_sections = []
+        self._conditioner_table = []
+        self._comments_table = []
 
     def fromRawSpecfile(self, raw):
         self._beginning = raw.beginning
         self._end = raw.end
         self._block_list, self._metastrings = self._processBlockList(raw.block_list)
+
+        self._toAbstractModel(self._metastrings, self._block_list)
+        #import json
+        #print(json.dumps(self.metastrings_to_json()))
+        #exit(1)
 
         return self
 
@@ -23,7 +81,7 @@ class SpecModel(object):
         for single_block in block_list:
 
             if single_block.block_type == BlockTypes.HeaderTagType:
-                generated_metastrings.append( HeaderTagMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( HeaderTagMetastring().fromBlockType(single_block) )
                 clean_block = HeaderTagMetastring().cleanBlockType(single_block)
                 if predicate_list != []:
                     # TODO(jchaloup): register the AP in the conditioner table as well
@@ -32,7 +90,7 @@ class SpecModel(object):
                 continue
 
             if single_block.block_type == BlockTypes.CommentType:
-                generated_metastrings.append( CommentMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( CommentMetastring().fromBlockType(single_block) )
                 clean_block = CommentMetastring().cleanBlockType(single_block)
                 if predicate_list != []:
                     # TODO(jchaloup): register the AP in the conditioner table as well
@@ -41,7 +99,7 @@ class SpecModel(object):
                 continue
 
             if single_block.block_type == BlockTypes.MacroDefinitionType:
-                generated_metastrings.append( MacroDefinitionMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( MacroDefinitionMetastring().fromBlockType(single_block) )
                 clean_block = MacroDefinitionMetastring().cleanBlockType(single_block)
                 if predicate_list != []:
                     # TODO(jchaloup): register the AP in the conditioner table as well
@@ -51,7 +109,7 @@ class SpecModel(object):
 
             if single_block.block_type == BlockTypes.SectionTagType:
                 if single_block.keyword.strip() == "changelog":
-                    generated_metastrings.append( ChangelogMetastring().fromBlockType(single_block).to_str() )
+                    generated_metastrings.append( ChangelogMetastring().fromBlockType(single_block) )
                     clean_block = ChangelogMetastring().cleanBlockType(single_block)
                     if predicate_list != []:
                         # TODO(jchaloup): register the AP in the conditioner table as well
@@ -61,7 +119,7 @@ class SpecModel(object):
 
                 if single_block.keyword.strip() == "package":
                     clean_block = SectionMetastring().cleanBlockType(single_block)
-                    generated_metastrings.append( SectionMetastring().fromBlockType(single_block).to_str() )
+                    generated_metastrings.append( SectionMetastring().fromBlockType(single_block) )
 
                     if single_block.content != []:
                         clean_block.content, metastring_children = self._processBlockList(single_block.content, predicate_list)
@@ -73,7 +131,7 @@ class SpecModel(object):
                     processed_blocks.append(clean_block)
                     continue
 
-                generated_metastrings.append( SectionMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( SectionMetastring().fromBlockType(single_block) )
                 clean_block = SectionMetastring().cleanBlockType(single_block)
                 if predicate_list != []:
                     # TODO(jchaloup): register the AP in the conditioner table as well
@@ -82,7 +140,7 @@ class SpecModel(object):
                 continue
 
             if single_block.block_type == BlockTypes.ConditionType:
-                generated_metastrings.append( ConditionMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( ConditionMetastring().fromBlockType(single_block) )
                 clean_block = ConditionMetastring().cleanBlockType(single_block)
 
                 if single_block.content != []:
@@ -99,7 +157,7 @@ class SpecModel(object):
                 continue
 
             if single_block.block_type == BlockTypes.MacroConditionType:
-                generated_metastrings.append( MacroConditionMetastring().fromBlockType(single_block).to_str() )
+                generated_metastrings.append( MacroConditionMetastring().fromBlockType(single_block) )
                 clean_block = MacroConditionMetastring().cleanBlockType(single_block)
 
                 if single_block.content != []:
@@ -120,15 +178,141 @@ class SpecModel(object):
 
         return processed_blocks, generated_metastrings
 
+    def _toAbstractModel(self, metastrings, block_list):
+
+        ms_idx = 0
+        for i, block in enumerate(block_list):
+            if block.block_type == BlockTypes.MacroDefinitionType:
+                metastrings[ms_idx].setBlockIdx(ModelTypes.Macros, len(self._metadata_macros))
+                #print repr(metastrings[ms_idx].to_str()), block, len(self._metadata_macros)
+                self._metadata_macros.append(block)
+                ms_idx = ms_idx + 1
+                continue
+
+            if block.block_type == BlockTypes.MacroConditionType:
+                # TODO(jchaloup): Should it be under the macros or under its own category?
+                metastrings[ms_idx].setBlockIdx(ModelTypes.Macros, len(self._metadata_macros))
+                #print repr(metastrings[ms_idx].to_str()), metastrings[ms_idx], block, len(self._metadata_macros)
+                self._metadata_macros.append(block)
+                ms_idx = ms_idx + 1
+                if block.content != []:
+                    self._toAbstractModel(metastrings[ms_idx], block.content)
+                    ms_idx = ms_idx + 1
+                continue
+
+            if block.block_type == BlockTypes.CommentType:
+                metastrings[ms_idx].setBlockIdx(ModelTypes.Comment, len(self._comments_table))
+                #print repr(metastrings[ms_idx].to_str()), block, len(self._comments_table)
+                self._comments_table.append(block)
+                ms_idx = ms_idx + 1
+                continue
+
+            if block.block_type == BlockTypes.HeaderTagType:
+                metastrings[ms_idx].setBlockIdx(ModelTypes.Tag, len(self._metadata_tags))
+                #print repr(metastrings[ms_idx].to_str()), block, len(self._metadata_tags)
+                self._metadata_tags.append(block)
+                ms_idx = ms_idx + 1
+                continue
+
+            if block.block_type == BlockTypes.ConditionType:
+                metastrings[ms_idx].setBlockIdx(ModelTypes.Condition, len(self._conditioner_table))
+                #print repr(metastrings[ms_idx].to_str()), block, len(self._conditioner_table)
+                self._conditioner_table.append(block.expression)
+                ms_idx = ms_idx + 1
+                # TODO(jchaloup): distribute the APs properly
+                if block.content != []:
+                    self._toAbstractModel(metastrings[ms_idx], block.content)
+                    ms_idx = ms_idx + 1
+                if block.else_body != []:
+                    self._toAbstractModel(metastrings[ms_idx], block.else_body)
+                    ms_idx = ms_idx + 1
+                continue
+
+            if block.block_type == BlockTypes.SectionTagType:
+                if block.keyword == "description":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Description, len(self._descriptions))
+                    #print repr(metastrings[ms_idx].to_str()), block, len(self._descriptions)
+                    self._descriptions.append(block)
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "package":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Package, len(self._packages))
+                    #print repr(metastrings[ms_idx].to_str()), block, len(self._packages)
+                    self._packages.append(block)
+                    ms_idx = ms_idx + 1
+                    if block.content != []:
+                        self._toAbstractModel(metastrings[ms_idx], block.content)
+                        ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "files":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Files, len(self._files))
+                    #print repr(metastrings[ms_idx].to_str()), block, len(self._files)
+                    self._files.append(block)
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "prep":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Prep)
+                    #print repr(metastrings[ms_idx].to_str()), block, 0
+                    self._prep = block
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "build":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Build)
+                    #print repr(metastrings[ms_idx].to_str()), block, 0
+                    self._build = block
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "install":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Install)
+                    #print repr(metastrings[ms_idx].to_str()), block, 0
+                    self._install = block
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "check":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Check)
+                    #print repr(metastrings[ms_idx].to_str()), block, 0
+                    self._check = block
+                    ms_idx = ms_idx + 1
+                    continue
+                if block.keyword == "changelog":
+                    metastrings[ms_idx].setBlockIdx(ModelTypes.Changelog)
+                    #print repr(metastrings[ms_idx].to_str()), block, 0
+                    self._changelog = block
+                    ms_idx = ms_idx + 1
+                    continue
+
+                #print block.keyword
+                metastrings[ms_idx].setBlockIdx(ModelTypes.OtherSection, len(self._other_sections))
+                #print repr(metastrings[ms_idx].to_str()), block, len(self._other_sections)
+                self._other_sections.append(block)
+                ms_idx = ms_idx + 1
+                continue
+
+            raise BlockTypeUnknown("Block type {} unknown".format(block.block_type))
+
+        return self
+
     def _metastring_list_to_str(self, metastring_list):
         str = ""
         for item in metastring_list:
             if isinstance(item, list):
                 str += self._metastring_list_to_str(item)
                 continue
-            str += "#" + item
+            str += item.to_str()
 
         return str
+
+    def _metastring_list_to_json(self, metastring_list):
+        data = []
+        for item in metastring_list:
+            if isinstance(item, list):
+                data.append(self._metastring_list_to_json(item))
+                continue
+            data.append(item.to_str())
+        return data
+
+    def metastrings_to_json(self):
+        return self._metastring_list_to_json(self._metastrings)
 
     def metastrings_to_str(self):
         return self._beginning + self._metastring_list_to_str(self._metastrings) + self._end

--- a/specparser.g
+++ b/specparser.g
@@ -48,12 +48,11 @@ class SectionBlock(Block):
 
 class PackageBlock(Block):
     def __init__(self, keyword, parameters, subname, content):
-        self.block_type = BlockTypes.SectionTagType
+        self.block_type = BlockTypes.PackageTagType
         self.keyword = keyword
         self.content = content
         self.parameters = parameters
         self.subname = subname
-        self.name = None
         self.AP = None
 
     def to_json(self):
@@ -68,7 +67,7 @@ class PackageBlock(Block):
 
 class ChangelogBlock(Block):
     def __init__(self, keyword, content):
-        self.block_type = BlockTypes.SectionTagType
+        self.block_type = BlockTypes.ChangelogTagType
         self.keyword = keyword
         self.content = content
         self.AP = None

--- a/specparser.py
+++ b/specparser.py
@@ -2,14 +2,29 @@ from __future__ import print_function
 import json
 from abstract_model import RawSpecFile, BlockTypes
 
-class HeaderTagBlock(object):
+class Block(object):
+
+    def _filter(self, data):
+        return {k:v for k,v in data.items() if v != None and v != []}
+
+class HeaderTagBlock(Block):
     def __init__(self, key, content, option=None):
         self.block_type = BlockTypes.HeaderTagType
         self.key = key
         self.option = option
         self.content = content
+        self.AP = None
 
-class SectionBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "key": self.key,
+          "option": self.option,
+          "content": self.content,
+        })
+
+class SectionBlock(Block):
     def __init__(self, keyword, parameters, name, subname, content):
         self.block_type = BlockTypes.SectionTagType
         self.keyword = keyword
@@ -17,48 +32,122 @@ class SectionBlock(object):
         self.parameters = parameters
         self.subname = subname
         self.name = name
+        self.AP = None
 
-class PackageBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "keyword": self.keyword,
+          # TODO(jchaloup): Make sure the content of a general section is always a string
+          "content": self.content if isinstance(self.content, basestring) else map(lambda l: l.to_json(), self.content),
+          "parameters": self.parameters,
+          "subname": self.subname,
+          "name": self.name
+        })
+
+class PackageBlock(Block):
     def __init__(self, keyword, parameters, subname, content):
         self.block_type = BlockTypes.SectionTagType
         self.keyword = keyword
         self.content = content
         self.parameters = parameters
         self.subname = subname
+        self.name = None
+        self.AP = None
 
-class ChangelogBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "keyword": self.keyword,
+          "content": map(lambda l: l.to_json(), self.content),
+          "parameters": self.parameters,
+          "subname": self.subname
+        })
+
+class ChangelogBlock(Block):
     def __init__(self, keyword, content):
         self.block_type = BlockTypes.SectionTagType
         self.keyword = keyword
         self.content = content
+        self.AP = None
 
-class MacroDefinitionBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "keyword": self.keyword,
+          "content": self.content
+        })
+
+class MacroDefinitionBlock(Block):
     def __init__(self, name, keyword, options, body):
         self.block_type = BlockTypes.MacroDefinitionType
         self.name = name
         self.keyword = keyword
         self.options = options
         self.body = body
+        self.AP = None
 
-class MacroUndefinitionBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "name": self.name,
+          "keyword": self.keyword,
+          "options": self.options,
+          "body": self.body,
+        })
+
+class MacroUndefinitionBlock(Block):
     def __init__(self, name, keyword):
         self.block_type = BlockTypes.MacroUndefinitionType
         self.name = name
         self.keyword = keyword
+        self.AP = None
 
-class MacroConditionBlock(object):
-    def __init__(self, name, condition, content):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "name": self.name,
+          "keyword": self.keyword
+        })
+
+class MacroConditionBlock(Block):
+    def __init__(self, name, condition, content, ending = None):
         self.block_type = BlockTypes.MacroConditionType
         self.name = name
         self.condition = condition
         self.content = content
+        self.ending = ending
+        self.AP = None
 
-class CommentBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "name": self.name,
+          "condition": self.condition,
+          "content": map(lambda l: l.to_json(), self.content),
+          "ending": self.ending,
+        })
+
+class CommentBlock(Block):
     def __init__(self, content):
         self.block_type = BlockTypes.CommentType
         self.content = content
+        self.AP = None
 
-class ConditionBlock(object):
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "content": self.content,
+        })
+
+class ConditionBlock(Block):
     def __init__(self, keyword, expression, content, else_body, end_keyword, else_keyword):
         self.block_type = BlockTypes.ConditionType
         self.keyword = keyword
@@ -66,7 +155,21 @@ class ConditionBlock(object):
         self.content = content
         self.else_body = else_body
         self.end_keyword = end_keyword
+        # If else keyword is None, the else_body is ignored
         self.else_keyword = else_keyword
+        self.AP = None
+
+    def to_json(self):
+        return self._filter({
+          "AP": self.AP,
+          "block_type": self.block_type,
+          "keyword": self.keyword,
+          "expression": self.expression,
+          "content": map(lambda l: l.to_json(), self.content),
+          "else_keyword": self.else_keyword,
+          "else_body": map(lambda l: l.to_json(), self.else_body),
+          "end_keyword": self.end_keyword,
+        })
 
 
 # Begin -- grammar generated by Yapps
@@ -393,3 +496,6 @@ class RawSpecFileParser(object):
 
   def json(self):
      return json.loads(json.dumps(self._rawSpecfile, default=lambda o: o.__dict__, sort_keys=True))
+
+  def raw(self):
+    return self._rawSpecfile

--- a/specparser.py
+++ b/specparser.py
@@ -48,12 +48,11 @@ class SectionBlock(Block):
 
 class PackageBlock(Block):
     def __init__(self, keyword, parameters, subname, content):
-        self.block_type = BlockTypes.SectionTagType
+        self.block_type = BlockTypes.PackageTagType
         self.keyword = keyword
         self.content = content
         self.parameters = parameters
         self.subname = subname
-        self.name = None
         self.AP = None
 
     def to_json(self):
@@ -68,7 +67,7 @@ class PackageBlock(Block):
 
 class ChangelogBlock(Block):
     def __init__(self, keyword, content):
-        self.block_type = BlockTypes.SectionTagType
+        self.block_type = BlockTypes.ChangelogTagType
         self.keyword = keyword
         self.content = content
         self.AP = None

--- a/tests.py
+++ b/tests.py
@@ -66,6 +66,7 @@ def run_tests():
             else:
                 sys.stdout.write(intro + "\033[1;31m" + "FAIL!" + "\033[0;0m" + " (" + specfile_filename + ")\n")
                 failures += 1
+        #exit(1)
 
     print('\nAll tests checked, totalling ' + str(failures) + ' errors!')
 


### PR DESCRIPTION
This is backward incompatible change. This basically breaks portions of the tests and the mapping of the SpecModel -> GoSpecModel.

**Changes**:
- move all the metastring processing into classes (extraction, block cleaning, converting to string)
- make self-standing extraction of metastrings from a raw specfile
- make the block interpretation into self-standing class

**TODO** (as part of another PR):
- interpret more blocks (%files, %changelog, ...)
- fix mapping from SpecModel -> GoSpecModel and back
- define JSON Schema for the SpecModel
- ...
